### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/foodmarks/manage.py
+++ b/foodmarks/manage.py
@@ -5,7 +5,7 @@ try:
     imp.find_module('settings') # Assumed to be in the same directory.
 except ImportError:
     import sys
-    sys.stderr.write("Error: Can't find the file 'settings.py' in the directory containing %r. It appears you've customized things.\nYou'll have to run django-admin.py, passing it your settings module.\n" % __file__)
+    sys.stderr.write("Error: Can't find the file 'settings.py' in the directory containing {0!r}. It appears you've customized things.\nYou'll have to run django-admin.py, passing it your settings module.\n".format(__file__))
     sys.exit(1)
 
 import settings


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:StoicLoofah:foodmarks?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:StoicLoofah:foodmarks?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
